### PR TITLE
Add string_is_subset rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 Cargo.lock
+.vscode

--- a/schema.json
+++ b/schema.json
@@ -229,6 +229,22 @@
                             "properties": {
                                 "operator": {
                                     "type": "string",
+                                    "enum": ["string_is_subset"]
+                                },
+                                "value": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "required": ["operator", "value"],
+                            "properties": {
+                                "operator": {
+                                    "type": "string",
                                     "enum": ["string_contains_any"]
                                 },
                                 "value": {

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -298,6 +298,16 @@ pub fn string_does_not_contain_any(field: &str, val: Vec<&str>) -> Condition {
     }
 }
 
+pub fn string_is_subset(field: &str, val: Vec<&str>) -> Condition {
+    Condition::Condition {
+        field: field.into(),
+        constraint: Constraint::StringIsSubset(
+            val.into_iter().map(ToOwned::to_owned).collect(),
+        ),
+        path: None,
+    }
+}
+
 pub fn string_in(field: &str, val: Vec<&str>) -> Condition {
     Condition::Condition {
         field: field.into(),
@@ -549,7 +559,7 @@ pub fn bool_equals(field: &str, val: bool) -> Condition {
 #[cfg(test)]
 mod tests {
     use super::{
-        and, at_least, bool_equals, int_equals, int_in_range, or, string_equals,
+        and, at_least, bool_equals, int_equals, int_in_range, or, string_equals, string_is_subset
     };
     use crate::status::Status;
     use serde_json::{json, Value};
@@ -684,6 +694,25 @@ mod tests {
 
         rule = string_equals("bar", "baz");
         res = rule.check_value(&map);
+        assert_eq!(res.status, Status::NotMet);
+    }
+
+    #[test]
+    fn string_is_subset_rule() {
+        let map = json!({
+            "foo": ["a", "b"],
+        });
+
+        let rule = string_is_subset("foo", vec!["a", "c", "b"]);
+        let res = rule.check_value(&map);
+        assert_eq!(res.status, Status::Met);
+
+        let rule = string_is_subset("foo", vec!["a", "b"]);
+        let res = rule.check_value(&map);
+        assert_eq!(res.status, Status::Met);
+
+        let rule = string_is_subset("foo", vec!["a", "c"]);
+        let res = rule.check_value(&map);
         assert_eq!(res.status, Status::NotMet);
     }
 

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -18,6 +18,7 @@ pub enum Constraint {
     StringDoesNotContainAny(Vec<String>),
     StringIn(Vec<String>),
     StringNotIn(Vec<String>),
+    StringIsSubset(Vec<String>),
     IntEquals(i64),
     IntNotEquals(i64),
     IntContains(i64),
@@ -106,6 +107,18 @@ impl Constraint {
                             Status::Met
                         } else {
                             Status::NotMet
+                        }
+                    }
+                }
+            }
+            Constraint::StringIsSubset(ref s) => {
+                match Self::value_as_str_array(v) {
+                    None => Status::NotMet,
+                    Some(v) => {
+                        if v.into_iter().any(|y| !s.contains(&y.into())) {
+                            Status::NotMet
+                        } else {
+                            Status::Met
                         }
                     }
                 }
@@ -472,6 +485,6 @@ mod tests {
 
     #[test]
     fn available_operators() {
-        assert_eq!(Constraint::operators().len(), 37);
+        assert_eq!(Constraint::operators().len(), 38);
     }
 }


### PR DESCRIPTION

For example, 'string_is_subset' is hard to leverage existing constraints, thus creating this PR

```
    #[test]
    fn string_is_subset_rule() {
        let map = json!({
            "foo": ["a", "b"],
        });

        let rule = string_is_subset("foo", vec!["a", "c", "b"]);
        let res = rule.check_value(&map);
        assert_eq!(res.status, Status::Met);

        let rule = string_is_subset("foo", vec!["a", "b"]);
        let res = rule.check_value(&map);
        assert_eq!(res.status, Status::Met);

        let rule = string_is_subset("foo", vec!["a", "c"]);
        let res = rule.check_value(&map);
        assert_eq!(res.status, Status::NotMet);
    }
```